### PR TITLE
freetype needs bzip2 to compile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,10 @@ if(FONTCONFIG_FOUND)
 endif()
 
 if(FREETYPE_FOUND)
+    find_package(BZip2)
     include_directories(${FREETYPE_INCLUDE_DIRS})
-    list(APPEND CAIRO_LIBS ${FREETYPE_LIBRARY})
+    include_directories(${BZIP2_INCLUDE_DIR})
+    list(APPEND CAIRO_LIBS ${FREETYPE_LIBRARIES} ${BZIP2_LIBRARIES})
 endif()
 
 include_directories(src)


### PR DESCRIPTION
Thank you for this very useful thing for Windows developers!

I have included simple buildscript into the collection https://github.com/alex85k/winbuilds
When building debug version under VS2015 I had encountered the following errors:

```
freetype.lib(ftbzip2.obj) : error LNK2019: unresolved external symbol BZ2_bzDecompressInit referenced in function ft_bzip2_file_init [D:\winbuilds\cairo\src\cairo.vcxproj]
freetype.lib(ftbzip2.obj) : error LNK2019: unresolved external symbol BZ2_bzDecompress referenced in function ft_bzip2_file_fill_output [D:\winbuilds\cairo\src\cairo.vcxproj]
freetype.lib(ftbzip2.obj) : error LNK2019: unresolved external symbol BZ2_bzDecompressEnd referenced in function ft_bzip2_file_done [D:\winbuilds\cairo\src\cairo.vcxproj]
```

Seems that freetype (cmake-built from official repo) still needs bzip2d.lib when linking. Hope the proposed solution is right.
